### PR TITLE
Truncate if byte size overflow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Vernacular-ai/vcore
 go 1.12
 
 require (
-	github.com/Vernacular-ai/gorm v1.9.13
+	github.com/Vernacular-ai/gorm v1.9.15
 	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 // indirect
 	github.com/getsentry/sentry-go v0.2.1
 	github.com/google/go-cmp v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/Vernacular-ai/gorm v1.9.13 h1:Ua1SSF0FxTiCblTtNJpWBazGmAq+ISS/Ay7pwyu5O0Y=
 github.com/Vernacular-ai/gorm v1.9.13/go.mod h1:3Z7XvgyWbLkVIreXrvxb+X7Fa87DEtBIGD8NyxTRFvo=
+github.com/Vernacular-ai/gorm v1.9.15/go.mod h1:3Z7XvgyWbLkVIreXrvxb+X7Fa87DEtBIGD8NyxTRFvo=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=


### PR DESCRIPTION
* Update gorm version
* New method to truncate vorm.JsonbMap if it exceeds the byte-limit of the target DB